### PR TITLE
Small bug fix for finding the FPGA USB port number

### DIFF
--- a/scripts/list_enso_nics.sh
+++ b/scripts/list_enso_nics.sh
@@ -29,8 +29,15 @@ while read -r line; do
   device=$(echo "$line" | awk '{print $4}' | cut -d: -f1)
   device=$((10#$device))
 
+  bus=$(echo "$line" | cut -d " " -f 2)
+  bus=$((10#$bus))
+
+  # capture the right bus
+  bus_line=$(lsusb -t | grep "Bus .*${bus}\." -n | cut -d ":" -f 1)
+  fpga_bus="$(lsusb -t | tail -n +${bus_line} -)"
+
   # Get the port number from lsusb -t using the device number
-  port=$(lsusb -t | grep -m 1 "Dev $device" | awk '{print $3}')
+  port=$(echo "${fpga_bus}" | grep -m 1 "Dev $device" | awk '{print $3}')
   port=${port%?}
 
   # Combine bus and port to get the ID


### PR DESCRIPTION
At the moment, the `list_enso_nics.sh` script grabs the first device with a matching device number (regardless of bus number). This pull request just adds a couple of lines to grab the right bus first and then grep for the device number.

Some extra details:

Our output from `lsusb` is:
```Bus 003 Device 002: ID 09fb:6010 Altera Intel Stratix 10 MX FPGA Development Kit```

A portion of the output from `lsusb -t` is:
```
/:  Bus 04.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/6p, 5000M
    |__ Port 5: Dev 2, If 0, Class=Hub, Driver=hub/4p, 5000M
    |__ Port 6: Dev 3, If 0, Class=Hub, Driver=hub/4p, 5000M
/:  Bus 03.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/15p, 480M
    |__ Port 1: Dev 2, If 0, Class=Vendor Specific Class, Driver=, 480M
    |__ Port 1: Dev 2, If 1, Class=Vendor Specific Class, Driver=, 480M
    |__ Port 9: Dev 3, If 0, Class=Hub, Driver=hub/4p, 480M
    |__ Port 10: Dev 4, If 0, Class=Hub, Driver=hub/4p, 480M
```
The script was grabbing the device under Bus 04 and giving us 5 instead of 1 as the port number