### PR TITLE
Driver updates to support kernel v6.5

### DIFF
--- a/software/kernel/linux/intel_fpga_pcie_chr.c
+++ b/software/kernel/linux/intel_fpga_pcie_chr.c
@@ -338,7 +338,11 @@ static int chr_mmap(struct file *filp, struct vm_area_struct *vma) {
     return -EINVAL;
   }
   vma->vm_ops = &intel_fpga_vm_ops;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+  vm_flags_set(vma, VM_PFNMAP | VM_DONTCOPY | VM_DONTEXPAND);
+#else
   vma->vm_flags |= VM_PFNMAP | VM_DONTCOPY | VM_DONTEXPAND;
+#endif
   vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
   vma->vm_private_data = dev_bk;
 
@@ -378,7 +382,11 @@ int __init intel_fpga_pcie_chr_init(void) {
   }
 
   // Create a class of devices; this also populates sysfs entries
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+  global_bk.chr_class = class_create(INTEL_FPGA_PCIE_DRIVER_NAME);
+#else
   global_bk.chr_class = class_create(THIS_MODULE, INTEL_FPGA_PCIE_DRIVER_NAME);
+#endif
   if (IS_ERR(global_bk.chr_class)) {
     retval = PTR_ERR(global_bk.chr_class);
     INTEL_FPGA_PCIE_ERR("couldn't create device class.");


### PR DESCRIPTION
Made changes in the drivers to add support for the latest kernel (v6.5) available for Ubuntu 22.04.

Overview of the changes in [intel_fpga_pcie_chr.c](https://github.com/crossroadsfpga/enso/compare/linux-6.5-fix?expand=1#diff-ca358362a2a161e05bf278efa25c6c6258452cbddda89ac2152d3c6dd1b81355):

- VMA flags wrappers introduced in version 6.3: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=bc292ab00f6c7a661a8a605c714e8a148f629ef6
- class_create changes in version 6.4: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1aaba11da9aa7d7d6b52a74d45b31cac118295a1

Testing performed:
Tested compilation on scotchbuild (Kernel version 6.5) and mxhost (Kernel version 4.15). Verified that `echo` program works post compilation on scotchbuild.
